### PR TITLE
Portuguese: replaces "Amo-te" with "Eu te amo".

### DIFF
--- a/lib/love-you.json
+++ b/lib/love-you.json
@@ -156,7 +156,7 @@
   "persian": "عاشقتم ‎",
   "phuthi": "Giyakutshadza",
   "polish": "Kocham cię",
-  "portuguese": "Amo-te",
+  "portuguese": "Eu te amo",
   "punjabi": {
     "by_man": "ਮੈਂ ਤੈਨੂੰ ਪਿਆਰ ਕਰਦਾ ਹਾਂ",
     "by_woman": "ਮੈਂ ਤੈਨੂੰ ਪਿਆਰ ਕਰਦੀ ਹਾਂ"


### PR DESCRIPTION
Both are correct but "Eu te amo" is more common than "Amo-te".
